### PR TITLE
Crear archivo `.dockerignore`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.venv/
+.git/
+__pycache__/
+*.pyc


### PR DESCRIPTION
Crear el archivo ha reducido el tamaño de la imagen (es la primera), y sigue funcionando perfectamente

```
samuel@IdeaPad-Gaming-3-15ACH6:~/Workspace/fastapi-hexagonal$ docker image ls
REPOSITORY                       TAG       IMAGE ID       CREATED         SIZE
fastapi-hexagonal-dockerignore   latest    a4888611ccc1   5 seconds ago   124MB
<none>                           <none>    6891c8205277   5 hours ago     197MB
```